### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python example.py"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # TGBE
 A Text-Based Graphics-Engine for devices capable of running Python shell.
+
+[![Run on Repl.it](https://repl.it/badge/github/Supercolbat/TGBE)](https://repl.it/github/Supercolbat/TGBE)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).